### PR TITLE
fix/13 table overflow on blog

### DIFF
--- a/src/components/molecules/PostContent/PostContent.module.css
+++ b/src/components/molecules/PostContent/PostContent.module.css
@@ -67,7 +67,7 @@
   }
 
   & pre {
-    @apply text-lg mb-4 rounded-sm py-4 px-4 font-mono overflow-y-scroll;
+    @apply text-sm md:text-lg mb-4 rounded-sm py-4 px-4 font-mono overflow-x-scroll;
   }
 
   & blockquote {

--- a/src/components/molecules/PostContent/PostContent.module.css
+++ b/src/components/molecules/PostContent/PostContent.module.css
@@ -79,7 +79,7 @@
   }
 
   & table {
-    @apply overflow-scroll relative text-xs md:text-sm;
+    @apply block overflow-auto relative text-xs md:text-sm;
 
     thead {
       @apply bg-primary-purple2 text-white text-left;


### PR DESCRIPTION
## Description

This PR adds some minimal enhancements on mobile.

- **Fix table overflow on mobile**
- **reduce code text size on small devices**

## How to Test

Visit http://localhost:4322/blog/learning-react-native-basics/ on a mobile device from any browser. You'll notice the following:
1. Code blocks have overflow for x & y
2. Tables break layout contianers

## Before Updates

Overflow is visible on both x & y axis.

<img width="471" alt="Screenshot 2025-02-24 at 2 16 43 PM" src="https://github.com/user-attachments/assets/d8cafcff-7182-4ee3-9e25-3c8cf2ab241c" />
<img width="450" alt="Screenshot 2025-02-24 at 2 16 39 PM" src="https://github.com/user-attachments/assets/acc4c5d7-5ae1-4744-ab46-61345a040be6" />

## After 

Both tables and code blocks now will overflow scroll on the x axis.

<img width="361" alt="Screenshot 2025-02-24 at 2 16 20 PM" src="https://github.com/user-attachments/assets/893cda9f-2c00-489e-9ec0-d9018a175ce0" />
<img width="365" alt="Screenshot 2025-02-24 at 2 16 14 PM" src="https://github.com/user-attachments/assets/d7b469b0-1ac5-437d-825a-91044dfb248d" />

